### PR TITLE
Add _env suffix to os functions related to env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add `is_directory`, `is_file`, `make_directory`, `list_directory`,
   `delete_directory`, `recursive_delete` functions to `file` module.
-- Add `os` module with `get_all`, `get`, `set`, and `unset` functions.
+- Add `os` module with `get_all_env`, `get_env`, `set_env`, and `unset_env` functions.
 
 ## v0.6.0 - 2021-12-29
 

--- a/src/gleam/erlang/os.gleam
+++ b/src/gleam/erlang/os.gleam
@@ -7,42 +7,42 @@ import gleam/map.{Map}
 ///
 /// ## Examples
 ///
-///    > get_all()
+///    > get_all_env()
 ///    map.from_list([
 ///      #("SHELL", "/bin/bash"),
 ///      #("PWD", "/home/j3rn"),
 ///      ...
 ///    ])
 ///
-pub external fn get_all() -> Map(String, String) =
+pub external fn get_all_env() -> Map(String, String) =
   "gleam_erlang_ffi" "get_all_env"
 
 /// Returns the value associated with the given environment variable name.
 ///
 /// ## Examples
 ///
-///    > get("SHELL")
+///    > get_env("SHELL")
 ///    "/bin/bash"
 ///
-///    > get(name: "PWD")
+///    > get_env(name: "PWD")
 ///    "/home/j3rn"
 ///
-pub external fn get(name: String) -> Result(String, Nil) =
+pub external fn get_env(name: String) -> Result(String, Nil) =
   "gleam_erlang_ffi" "get_env"
 
 /// Associates the given value with the given environment variable name.
 ///
 /// ## Examples
 ///
-///    > set("MYVAR", "MYVALUE")
+///    > set_env("MYVAR", "MYVALUE")
 ///    Nil
-///    > get("MYVAR")
+///    > get_env("MYVAR")
 ///    "MYVALUE"
 ///
-///    > set(value: "MYVALUE", name: "MYVAR")
+///    > set_env(value: "MYVALUE", name: "MYVAR")
 ///    Nil
 ///
-pub external fn set(name: String, value: String) -> Nil =
+pub external fn set_env(name: String, value: String) -> Nil =
   "gleam_erlang_ffi" "set_env"
 
 /// Removes the environment variable with the given name.
@@ -51,15 +51,15 @@ pub external fn set(name: String, value: String) -> Nil =
 ///
 /// ## Examples
 ///
-///    > get("MYVAR")
+///    > get_env("MYVAR")
 ///    Ok("MYVALUE")
-///    > unset("MYVAR")
+///    > unset_env("MYVAR")
 ///    Nil
-///    > get("MYVAR")
+///    > get_env("MYVAR")
 ///    Error(Nil)
 ///
-///    > unset(name: "MYVAR")
+///    > unset_env(name: "MYVAR")
 ///    Nil
 ///
-pub external fn unset(name: String) -> Nil =
+pub external fn unset_env(name: String) -> Nil =
   "gleam_erlang_ffi" "unset_env"

--- a/test/gleam/erlang/env_test.gleam
+++ b/test/gleam/erlang/env_test.gleam
@@ -2,40 +2,40 @@ import gleam/erlang/os
 import gleam/map
 
 pub fn get_all_test() {
-  os.set("MYVAR", "MYVALUE")
+  os.set_env("MYVAR", "MYVALUE")
 
-  let vars = os.get_all()
+  let vars = os.get_all_env()
   assert Ok("MYVALUE") = map.get(vars, "MYVAR")
 
-  os.unset("MYVAR")
+  os.unset_env("MYVAR")
 }
 
 pub fn set_get_test() {
-  assert Nil = os.set("MYVAR", "MYVALUE")
-  assert Ok("MYVALUE") = os.get("MYVAR")
+  assert Nil = os.set_env("MYVAR", "MYVALUE")
+  assert Ok("MYVALUE") = os.get_env("MYVAR")
 
-  assert Nil = os.set(name: "MYVAR", value: "MYVALUE")
-  assert Ok("MYVALUE") = os.get(name: "MYVAR")
+  assert Nil = os.set_env(name: "MYVAR", value: "MYVALUE")
+  assert Ok("MYVALUE") = os.get_env(name: "MYVAR")
 
-  os.unset("MYVAR")
+  os.unset_env("MYVAR")
 }
 
 pub fn unset_test() {
-  os.set("MYVAR", "MYVALUE")
+  os.set_env("MYVAR", "MYVALUE")
 
-  assert Nil = os.unset("MYVAR")
-  assert Error(Nil) = os.get("MYVAR")
+  assert Nil = os.unset_env("MYVAR")
+  assert Error(Nil) = os.get_env("MYVAR")
 
-  os.set("MYVAR", "MYVALUE")
+  os.set_env("MYVAR", "MYVALUE")
 
-  assert Nil = os.unset(name: "MYVAR")
-  assert Error(Nil) = os.get(name: "MYVAR")
+  assert Nil = os.unset_env(name: "MYVAR")
+  assert Error(Nil) = os.get_env(name: "MYVAR")
 }
 
 pub fn get_non_existant_test() {
   // Just to make sure
-  os.unset("I_DONT_EXIST")
+  os.unset_env("I_DONT_EXIST")
 
-  assert Error(Nil) = os.get("I_DONT_EXIST")
-  assert Nil = os.unset("I_DONT_EXIST")
+  assert Error(Nil) = os.get_env("I_DONT_EXIST")
+  assert Nil = os.unset_env("I_DONT_EXIST")
 }


### PR DESCRIPTION
There was a suggestion to expand this module with more functionality, e.g. a binding to Erlang's `:os.type()`.