### PR TITLE
`DecodeErrors` for `atom.from_dynamic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8.0 - 2022-01-17
+
+- Use `DecodeErrors` in the `atom` module for the `from_dynamic` function.
+
 ## v0.7.0 - 2022-01-13
 
 - Add `is_directory`, `is_file`, `make_directory`, `list_directory`,

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "gleam_erlang"
 
-version = "0.7.0"
+version = "0.8.0"
 licences = ["Apache-2.0"]
 description = "A Gleam library for working with Erlang"
 
@@ -11,7 +11,7 @@ links = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.18"
+gleam_stdlib = "~> 0.19"
 
 [dev-dependencies]
-gleeunit = "~> 0.1"
+gleeunit = "~> 0.6"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.18.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2938F996BBB25D75E973226846CDDFA33AB5590AFC8A9D043A356EA85272510D" },
-  { name = "gleeunit", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "E8FDD4E31E0BBB87F625B0BB4DEABDE780180F1C2B15A4534442823066468638" },
+  { name = "gleam_stdlib", version = "0.19.3", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CA579C2FF0621E93FF6EFEF61BAFFCF0505732BA073F616E28878042F1A1F401" },
+  { name = "gleeunit", version = "0.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "77701A5E5A565727E1EEAC9196FB878D544049B6331CD0305B5A69699135EA1C" },
 ]
 
 [requirements]
-gleam_stdlib = "~> 0.18"
-gleeunit = "~> 0.1"
+gleam_stdlib = "~> 0.19"
+gleeunit = "~> 0.6"

--- a/src/gleam/erlang/atom.gleam
+++ b/src/gleam/erlang/atom.gleam
@@ -1,4 +1,4 @@
-import gleam/dynamic.{DecodeError, Dynamic}
+import gleam/dynamic.{DecodeErrors, Dynamic}
 
 /// Atom is a special string-like data-type that is most commonly used for
 /// interfacing with code written in other BEAM languages such as Erlang and
@@ -63,17 +63,17 @@ pub external fn create_from_string(String) -> Atom =
 pub external fn to_string(Atom) -> String =
   "gleam_erlang_ffi" "atom_to_string"
 
-/// Checks to see whether a Dynamic value is an atom, and return the atom if
+/// Checks to see whether a `Dynamic` value is an atom, and return the atom if
 /// it is.
 ///
 /// ## Examples
 ///
-///    > import gleam/atom
-///    > atom(from(atom.create_from_string("hello")))
-///    OK("hello")
+///    > import gleam/dynamic
+///    > from_dynamic(dynamic.from(create_from_string("hello")))
+///    Ok(create_from_string("hello"))
 ///
-///    > atom(from(123))
-///    Error(DecodeError(expected: "Int", found: "Int"))
+///    > from_dynamic(dynamic.from(123))
+///    Error([DecodeError(expected: "Atom", found: "Int")])
 ///
-pub external fn from_dynamic(from: Dynamic) -> Result(Atom, DecodeError) =
+pub external fn from_dynamic(from: Dynamic) -> Result(Atom, DecodeErrors) =
   "gleam_erlang_ffi" "atom_from_dynamic"

--- a/src/gleam/erlang/atom.gleam
+++ b/src/gleam/erlang/atom.gleam
@@ -73,7 +73,7 @@ pub external fn to_string(Atom) -> String =
 ///    Ok(create_from_string("hello"))
 ///
 ///    > from_dynamic(dynamic.from(123))
-///    Error([DecodeError(expected: "Atom", found: "Int")])
+///    Error([DecodeError(expected: "Atom", found: "Int", path: [])])
 ///
 pub external fn from_dynamic(from: Dynamic) -> Result(Atom, DecodeErrors) =
   "gleam_erlang_ffi" "atom_from_dynamic"

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -43,7 +43,7 @@ atom_to_string(S) ->
 atom_from_dynamic(Data) when is_atom(Data) ->
     {ok, Data};
 atom_from_dynamic(Data) ->
-    {error, {decode_error, <<"Atom">>, gleam@dynamic:classify(Data)}}.
+    {error, [{decode_error, <<"Atom">>, gleam@dynamic:classify(Data)}]}.
 
 -spec get_line(io:prompt()) -> {ok, unicode:unicode_binary()} | {error, eof | no_data}.
 get_line(Prompt) ->

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -43,7 +43,7 @@ atom_to_string(S) ->
 atom_from_dynamic(Data) when is_atom(Data) ->
     {ok, Data};
 atom_from_dynamic(Data) ->
-    {error, [{decode_error, <<"Atom">>, gleam@dynamic:classify(Data)}]}.
+    {error, [{decode_error, <<"Atom">>, gleam@dynamic:classify(Data), []}]}.
 
 -spec get_line(io:prompt()) -> {ok, unicode:unicode_binary()} | {error, eof | no_data}.
 get_line(Prompt) ->

--- a/test/gleam/erlang/atom_test.gleam
+++ b/test/gleam/erlang/atom_test.gleam
@@ -1,5 +1,5 @@
 import gleam/erlang/atom
-import gleam/dynamic.{DecodeErrors}
+import gleam/dynamic.{DecodeError}
 
 pub fn from_string_test() {
   atom.create_from_string("this is an existing atom")
@@ -52,12 +52,12 @@ pub fn from_dynamic_test() {
     |> atom.from_dynamic
   assert True = result == Ok(atom.create_from_string("ok"))
 
-  assert Error([DecodeError(expected: "Atom", found: "Int")]) =
+  assert Error([DecodeError(expected: "Atom", found: "Int", path: [])]) =
     1
     |> dynamic.from
     |> atom.from_dynamic
 
-  assert Error([DecodeError(expected: "Atom", found: "List")]) =
+  assert Error([DecodeError(expected: "Atom", found: "List", path: [])]) =
     []
     |> dynamic.from
     |> atom.from_dynamic

--- a/test/gleam/erlang/atom_test.gleam
+++ b/test/gleam/erlang/atom_test.gleam
@@ -1,5 +1,5 @@
 import gleam/erlang/atom
-import gleam/dynamic.{DecodeError}
+import gleam/dynamic.{DecodeErrors}
 
 pub fn from_string_test() {
   atom.create_from_string("this is an existing atom")
@@ -52,12 +52,12 @@ pub fn from_dynamic_test() {
     |> atom.from_dynamic
   assert True = result == Ok(atom.create_from_string("ok"))
 
-  assert Error(DecodeError(expected: "Atom", found: "Int")) =
+  assert Error([DecodeError(expected: "Atom", found: "Int")]) =
     1
     |> dynamic.from
     |> atom.from_dynamic
 
-  assert Error(DecodeError(expected: "Atom", found: "List")) =
+  assert Error([DecodeError(expected: "Atom", found: "List")]) =
     []
     |> dynamic.from
     |> atom.from_dynamic


### PR DESCRIPTION
Updates the `atom` module for the new `gleam/dynamic.{DecodeErrors}` convention.