### PR TITLE
Add more selecting_record functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The `gleam/erlang/process` module gains functions `selecting_record5`
+  through to `selecting_record8`.
 - The `file` module loses the `is_file` function; gains the `FileType`,
   `Access`, and `FileInfo` types; and gains the `is_regular`, `file_info`,
   `link_info`, `file_exists`, and `link_exists` functions.

--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -321,6 +321,109 @@ pub fn selecting_record4(
   insert_selector_handler(selector, #(tag, 4), handler)
 }
 
+/// Add a handler to a selector for 5 element tuple messages with a given tag
+/// element in the first position.
+///
+/// Typically you want to use the `selecting` function with a `Subject` instead,
+/// but this function may be useful if you need to receive messages sent from
+/// other BEAM languages that do not use the `Subject` type.
+///
+pub fn selecting_record5(
+  selector: Selector(payload),
+  tag: tag,
+  mapping transform: fn(Dynamic, Dynamic, Dynamic, Dynamic) -> payload,
+) -> Selector(payload) {
+  let handler = fn(message: #(tag, Dynamic, Dynamic, Dynamic, Dynamic)) {
+    transform(message.1, message.2, message.3, message.4)
+  }
+  insert_selector_handler(selector, #(tag, 5), handler)
+}
+
+/// Add a handler to a selector for 6 element tuple messages with a given tag
+/// element in the first position.
+///
+/// Typically you want to use the `selecting` function with a `Subject` instead,
+/// but this function may be useful if you need to receive messages sent from
+/// other BEAM languages that do not use the `Subject` type.
+///
+pub fn selecting_record6(
+  selector: Selector(payload),
+  tag: tag,
+  mapping transform: fn(Dynamic, Dynamic, Dynamic, Dynamic, Dynamic) -> payload,
+) -> Selector(payload) {
+  let handler = fn(message: #(tag, Dynamic, Dynamic, Dynamic, Dynamic, Dynamic)) {
+    transform(message.1, message.2, message.3, message.4, message.5)
+  }
+  insert_selector_handler(selector, #(tag, 6), handler)
+}
+
+/// Add a handler to a selector for 7 element tuple messages with a given tag
+/// element in the first position.
+///
+/// Typically you want to use the `selecting` function with a `Subject` instead,
+/// but this function may be useful if you need to receive messages sent from
+/// other BEAM languages that do not use the `Subject` type.
+///
+pub fn selecting_record7(
+  selector: Selector(payload),
+  tag: tag,
+  mapping transform: fn(Dynamic, Dynamic, Dynamic, Dynamic, Dynamic, Dynamic) ->
+    payload,
+) -> Selector(payload) {
+  let handler = fn(
+    message: #(tag, Dynamic, Dynamic, Dynamic, Dynamic, Dynamic, Dynamic),
+  ) {
+    transform(message.1, message.2, message.3, message.4, message.5, message.6)
+  }
+  insert_selector_handler(selector, #(tag, 7), handler)
+}
+
+/// Add a handler to a selector for 8 element tuple messages with a given tag
+/// element in the first position.
+///
+/// Typically you want to use the `selecting` function with a `Subject` instead,
+/// but this function may be useful if you need to receive messages sent from
+/// other BEAM languages that do not use the `Subject` type.
+///
+pub fn selecting_record8(
+  selector: Selector(payload),
+  tag: tag,
+  mapping transform: fn(
+    Dynamic,
+    Dynamic,
+    Dynamic,
+    Dynamic,
+    Dynamic,
+    Dynamic,
+    Dynamic,
+  ) ->
+    payload,
+) -> Selector(payload) {
+  let handler = fn(
+    message: #(
+      tag,
+      Dynamic,
+      Dynamic,
+      Dynamic,
+      Dynamic,
+      Dynamic,
+      Dynamic,
+      Dynamic,
+    ),
+  ) {
+    transform(
+      message.1,
+      message.2,
+      message.3,
+      message.4,
+      message.5,
+      message.6,
+      message.7,
+    )
+  }
+  insert_selector_handler(selector, #(tag, 8), handler)
+}
+
 type AnythingSelectorTag {
   Anything
 }

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -234,11 +234,15 @@ pub fn selecting_record_test() {
   send(process.self(), #("a", 1))
   send(process.self(), #("b", 2, 3))
   send(process.self(), #("c", 4, 5, 6))
-  send(process.self(), "d")
+  send(process.self(), #("d", 7, 8, 9, 10))
+  send(process.self(), #("e", 11, 12, 13, 14, 15))
+  send(process.self(), #("f", 16, 17, 18, 19, 20, 21))
+  send(process.self(), #("g", 22, 23, 24, 25, 26, 27, 28))
+  send(process.self(), "h")
 
   let assert Error(Nil) =
     process.new_selector()
-    |> process.selecting_record2("d", dynamic.unsafe_coerce)
+    |> process.selecting_record2("h", dynamic.unsafe_coerce)
     |> process.select(0)
 
   let assert Error(Nil) =
@@ -254,6 +258,72 @@ pub fn selecting_record_test() {
     |> process.selecting_record3(
       "c",
       fn(a, b) { #(dynamic.unsafe_coerce(a), dynamic.unsafe_coerce(b)) },
+    )
+    |> process.select(0)
+
+  let assert Ok(#(22, 23, 24, 25, 26, 27, 28)) =
+    process.new_selector()
+    |> process.selecting_record8(
+      "g",
+      fn(a, b, c, d, e, f, g) {
+        #(
+          dynamic.unsafe_coerce(a),
+          dynamic.unsafe_coerce(b),
+          dynamic.unsafe_coerce(c),
+          dynamic.unsafe_coerce(d),
+          dynamic.unsafe_coerce(e),
+          dynamic.unsafe_coerce(f),
+          dynamic.unsafe_coerce(g),
+        )
+      },
+    )
+    |> process.select(0)
+
+  let assert Ok(#(16, 17, 18, 19, 20, 21)) =
+    process.new_selector()
+    |> process.selecting_record7(
+      "f",
+      fn(a, b, c, d, e, f) {
+        #(
+          dynamic.unsafe_coerce(a),
+          dynamic.unsafe_coerce(b),
+          dynamic.unsafe_coerce(c),
+          dynamic.unsafe_coerce(d),
+          dynamic.unsafe_coerce(e),
+          dynamic.unsafe_coerce(f),
+        )
+      },
+    )
+    |> process.select(0)
+
+  let assert Ok(#(11, 12, 13, 14, 15)) =
+    process.new_selector()
+    |> process.selecting_record6(
+      "e",
+      fn(a, b, c, d, e) {
+        #(
+          dynamic.unsafe_coerce(a),
+          dynamic.unsafe_coerce(b),
+          dynamic.unsafe_coerce(c),
+          dynamic.unsafe_coerce(d),
+          dynamic.unsafe_coerce(e),
+        )
+      },
+    )
+    |> process.select(0)
+
+  let assert Ok(#(7, 8, 9, 10)) =
+    process.new_selector()
+    |> process.selecting_record5(
+      "d",
+      fn(a, b, c, d) {
+        #(
+          dynamic.unsafe_coerce(a),
+          dynamic.unsafe_coerce(b),
+          dynamic.unsafe_coerce(c),
+          dynamic.unsafe_coerce(d),
+        )
+      },
     )
     |> process.select(0)
 


### PR DESCRIPTION
Functions for selecting records up to at-least length 8 are required for dealing with `otp` networking libs.