### PR TITLE
docs(process): Correctly format links

### DIFF
--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -683,8 +683,9 @@ fn erlang_send_exit(to to: Pid, because because: whatever) -> Bool
 /// Sends an exit signal to a process, indicating that the process is to shut
 /// down.
 ///
-/// See the [Erlang documentation][erl] for more information.
-/// [erl]: http://erlang.org/doc/man/erlang.html#exit-2
+/// See the [Erlang documentation][1] for more information.
+///
+/// [1]: http://erlang.org/doc/man/erlang.html#exit-2
 ///
 pub fn send_exit(to pid: Pid) -> Nil {
   erlang_send_exit(pid, Normal)
@@ -694,8 +695,9 @@ pub fn send_exit(to pid: Pid) -> Nil {
 /// Sends an exit signal to a process, indicating that the process is to shut
 /// down due to an abnormal reason such as a failure.
 ///
-/// See the [Erlang documentation][erl] for more information.
-/// [erl]: http://erlang.org/doc/man/erlang.html#exit-2
+/// See the [Erlang documentation][1] for more information.
+///
+/// [1]: http://erlang.org/doc/man/erlang.html#exit-2
 ///
 pub fn send_abnormal_exit(pid: Pid, reason: String) -> Nil {
   erlang_send_exit(pid, Abnormal(reason))


### PR DESCRIPTION
These links appear broken on the hexdocs page

<img width="1108" alt="image" src="https://github.com/gleam-lang/erlang/assets/6134511/f208ed18-9518-4268-ab53-8d2ab3874a07">


I aligned it just like I saw how the [start](https://hexdocs.pm/gleam_erlang/gleam/erlang/process.html#start) function was formatted.

https://github.com/gleam-lang/erlang/blob/main/src/gleam/erlang/process.gleam#L24-L27