### PR TITLE
Clarify timeout is milliseconds

### DIFF
--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -125,13 +125,15 @@ pub fn send(subject: Subject(message), message: message) -> Nil {
 /// To wait for messages from multiple `Subject`s at the same time see the
 /// `Selector` type.
 ///
+/// The `within` parameter specifies the timeout duration in milliseconds.
+///
 pub fn receive(
   from subject: Subject(message),
-  within milliseconds: Int,
+  within timeout: Int,
 ) -> Result(message, Nil) {
   new_selector()
   |> selecting(subject, fn(x) { x })
-  |> select(within: milliseconds)
+  |> select(within: timeout)
 }
 
 /// A type that enables a process to wait for messages from multiple `Subject`s
@@ -177,6 +179,8 @@ pub fn new_selector() -> Selector(payload)
 ///
 /// To wait forever for the next message rather than for a limited amount of
 /// time see the `select_forever` function.
+///
+/// The `within` parameter specifies the timeout duration in milliseconds.
 ///
 @external(erlang, "gleam_erlang_ffi", "select")
 pub fn select(
@@ -545,6 +549,8 @@ pub type CallError(msg) {
 /// If the receiving process exits or does not reply within the allowed amount
 /// of time then an error is returned.
 ///
+/// The `within` parameter specifies the timeout duration in milliseconds.
+///
 pub fn try_call(
   subject: Subject(request),
   make_request: fn(Subject(response)) -> request,
@@ -583,6 +589,8 @@ pub fn try_call(
 /// If the receiving process exits or does not reply within the allowed amount
 /// of time the calling process crashes. If you wish an error to be returned
 /// instead see the `try_call` function.
+///
+/// The `within` parameter specifies the timeout duration in milliseconds.
 ///
 pub fn call(
   subject: Subject(request),


### PR DESCRIPTION
* Renamed internal variable for `within` to timeout, now most functions use timeout as opposed to milliseconds, or `within`
* Write documentation that timeout is expressed as milliseconds

The only function that remains is `select`. It uses `within`. [I looked through the `gleam_erlang_ffi`](https://github.com/gleam-lang/erlang/blob/main/src/gleam_erlang_ffi.erl#L115-L133) file but it does not use any `within` parameters. Is it inferred somehow that `within` is sent as `Timeout`? I do not know any erlang so I would need some help to clarify how the FFI understand which parameters are received on the erlang side.