### PR TITLE
Add FFI from erlang to start a node

### DIFF
--- a/test/gleam/erlang/node_tests.gleam
+++ b/test/gleam/erlang/node_tests.gleam
@@ -21,3 +21,11 @@ pub fn connect_not_alive_test() {
 pub fn to_atom_test() {
   let assert "nonode@nohost" = atom.to_string(node.to_atom(node.self()))
 }
+
+pub fn start_test() {
+  let a = node.self()
+  let _ =
+    node.start("node1", node.StartOptions(node.Shortnames, 60, 4, True, False))
+  let b = node.self()
+  let assert True = a != b
+}


### PR DESCRIPTION
This change pulls in the net_kernel::start/2 function from erlang along with adding some extra types to make the function more usable in gleam.

NOTE: epmd must be running in order for the new `start_test` to work since starting a node depends on epmd running. In my research, I could not find an easy way to start epmd or at least confirm if it is already started.