### PR TITLE
feat(process): added receive_forever

### DIFF
--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -136,6 +136,15 @@ pub fn receive(
   |> select(within: timeout)
 }
 
+/// Similar to the `receive` function but will wait forever for a message to
+/// arrive rather than timing out after a specified amount of time.
+///
+pub fn receive_forever(from subject: Subject(message)) -> message {
+  new_selector()
+  |> selecting(subject, fn(x) { x })
+  |> select_forever
+}
+
 /// A type that enables a process to wait for messages from multiple `Subject`s
 /// at the same time, returning whichever message arrives first.
 ///


### PR DESCRIPTION
Hey!

I just started using Gleam, this is a fantastic language & ecosystem you created, congrats!

While tinkering with processes, I discovered that `receive` was a wrapper for `select`, but `select_forever` had no equivalent, so I made one.

I'll try to add a test for the function too

