### PR TITLE
Fix docs example rendering and increase test timeouts

### DIFF
--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -64,10 +64,11 @@ pub type GetLineError {
 ///
 /// # Example
 ///
-///    > get_line("Language: ")
-///    // -> Language: <- gleam
-///    Ok("gleam\n")
-///
+/// ```gleam
+/// get_line("Language: ")
+/// // > Language: <- Gleam
+/// // -> Ok("Gleam\n")
+/// ```
 @external(erlang, "gleam_erlang_ffi", "get_line")
 pub fn get_line(prompt prompt: String) -> Result(String, GetLineError)
 
@@ -169,7 +170,7 @@ pub fn make_reference() -> Reference
 /// # Example
 ///
 /// ```gleam
-/// > erlang.priv_directory("my_app")
+/// erlang.priv_directory("my_app")
 /// // -> Ok("/some/location/my_app/priv")
 /// ```
 /// 

--- a/src/gleam/erlang/atom.gleam
+++ b/src/gleam/erlang/atom.gleam
@@ -31,10 +31,11 @@ pub type FromStringError {
 /// ## Examples
 /// ```gleam
 /// from_string("ok")
-/// // Ok(create_from_string("ok"))
-///
+/// // -> Ok(create_from_string("ok"))
+/// ```
+/// ```gleam
 /// from_string("some_new_atom")
-/// // Error(AtomNotLoaded)
+/// // -> Error(AtomNotLoaded)
 /// ```
 ///
 @external(erlang, "gleam_erlang_ffi", "atom_from_string")
@@ -59,7 +60,7 @@ pub fn create_from_string(a: String) -> Atom
 /// ```gleam
 /// let ok_atom = create_from_string("ok")
 /// to_string(ok_atom)
-/// // "ok"
+/// // -> "ok"
 /// ```
 ///
 @external(erlang, "erlang", "atom_to_binary")
@@ -72,10 +73,11 @@ pub fn to_string(a: Atom) -> String
 /// ```gleam
 /// import gleam/dynamic
 /// from_dynamic(dynamic.from(create_from_string("hello")))
-/// // Ok(create_from_string("hello"))
-///
+/// // -> Ok(create_from_string("hello"))
+/// ```
+/// ```gleam
 /// from_dynamic(dynamic.from(123))
-/// // Error([DecodeError(expected: "Atom", found: "Int", path: [])])
+/// // -> Error([DecodeError(expected: "Atom", found: "Int", path: [])])
 /// ```
 ///
 @external(erlang, "gleam_erlang_ffi", "atom_from_dynamic")

--- a/src/gleam/erlang/os.gleam
+++ b/src/gleam/erlang/os.gleam
@@ -26,6 +26,7 @@ pub fn get_all_env() -> Dict(String, String)
 /// get_env("SHELL")
 /// // -> "/bin/bash"
 /// ```
+/// 
 /// ```gleam
 /// get_env(name: "PWD")
 /// // -> "/home/j3rn"
@@ -44,6 +45,7 @@ pub fn get_env(name name: String) -> Result(String, Nil)
 /// get_env("MYVAR")
 /// // -> "MYVALUE"
 /// ```
+/// 
 /// ```gleam
 /// set_env(value: "MYVALUE", name: "MYVAR")
 /// // -> Nil
@@ -54,7 +56,6 @@ pub fn get_env(name name: String) -> Result(String, Nil)
 @external(erlang, "gleam_erlang_ffi", "set_env")
 pub fn set_env(name name: String, value value: String) -> Nil
 
-// -> Error(Nil)
 /// Removes the environment variable with the given name.
 ///
 /// Returns Nil regardless of whether the variable ever existed.
@@ -69,6 +70,7 @@ pub fn set_env(name name: String, value value: String) -> Nil
 /// get_env("MYVAR")
 /// // -> Error(Nil)
 /// ```
+/// 
 /// ```gleam
 /// unset_env(name: "MYVAR")
 /// // ->  Nil
@@ -101,10 +103,12 @@ pub type OsFamily {
 /// family()
 /// // -> Linux
 /// ```
+/// 
 /// ```gleam
 /// family()
 /// // -> Darwin
 /// ```
+/// 
 /// ```gleam
 /// family()
 /// // -> Other("sunos")

--- a/src/gleam/erlang/os.gleam
+++ b/src/gleam/erlang/os.gleam
@@ -7,12 +7,14 @@ import gleam/dict.{type Dict}
 ///
 /// ## Examples
 ///
-///    > get_all_env()
-///    dict.from_list([
-///      #("SHELL", "/bin/bash"),
-///      #("PWD", "/home/j3rn"),
-///      ...
-///    ])
+/// ```gleam
+/// get_all_env()
+/// // -> dict.from_list([
+/// //  #("SHELL", "/bin/bash"),
+/// //  #("PWD", "/home/j3rn"),
+/// //  ...
+/// // ])
+/// ```
 ///
 @external(erlang, "gleam_erlang_ffi", "get_all_env")
 pub fn get_all_env() -> Dict(String, String)
@@ -20,12 +22,14 @@ pub fn get_all_env() -> Dict(String, String)
 /// Returns the value associated with the given environment variable name.
 ///
 /// ## Examples
-///
-///    > get_env("SHELL")
-///    "/bin/bash"
-///
-///    > get_env(name: "PWD")
-///    "/home/j3rn"
+/// ```gleam
+/// get_env("SHELL")
+/// // -> "/bin/bash"
+/// ```
+/// ```gleam
+/// get_env(name: "PWD")
+/// // -> "/home/j3rn"
+/// ```
 ///
 @external(erlang, "gleam_erlang_ffi", "get_env")
 pub fn get_env(name name: String) -> Result(String, Nil)
@@ -34,33 +38,43 @@ pub fn get_env(name name: String) -> Result(String, Nil)
 ///
 /// ## Examples
 ///
-///    > set_env("MYVAR", "MYVALUE")
-///    Nil
-///    > get_env("MYVAR")
-///    "MYVALUE"
-///
-///    > set_env(value: "MYVALUE", name: "MYVAR")
-///    Nil
+/// ```gleam
+/// set_env("MYVAR", "MYVALUE")
+/// // -> Nil
+/// get_env("MYVAR")
+/// // -> "MYVALUE"
+/// ```
+/// ```gleam
+/// set_env(value: "MYVALUE", name: "MYVAR")
+/// // -> Nil
+/// get_env("MYVAR")
+/// // -> "MYVALUE"
+/// ```
 ///
 @external(erlang, "gleam_erlang_ffi", "set_env")
 pub fn set_env(name name: String, value value: String) -> Nil
 
+// -> Error(Nil)
 /// Removes the environment variable with the given name.
 ///
 /// Returns Nil regardless of whether the variable ever existed.
 ///
 /// ## Examples
 ///
-///    > get_env("MYVAR")
-///    Ok("MYVALUE")
-///    > unset_env("MYVAR")
-///    Nil
-///    > get_env("MYVAR")
-///    Error(Nil)
-///
-///    > unset_env(name: "MYVAR")
-///    Nil
-///
+/// ```gleam
+/// get_env("MYVAR")
+/// // -> Ok("MYVALUE")
+/// unset_env("MYVAR")
+/// // -> Nil
+/// get_env("MYVAR")
+/// // -> Error(Nil)
+/// ```
+/// ```gleam
+/// unset_env(name: "MYVAR")
+/// // ->  Nil
+/// get_env("MYVAR")
+/// // -> Error(Nil)
+/// ```
 @external(erlang, "gleam_erlang_ffi", "unset_env")
 pub fn unset_env(name name: String) -> Nil
 
@@ -83,13 +97,18 @@ pub type OsFamily {
 /// Unknown kernels are reported as `Other(String)`; e.g. `Other("sunos")`.
 ///
 /// ## Examples
-///
-///    > family()
-///    Linux
-///    > family()
-///    Darwin
-///    > family()
-///    Other("sunos")
+/// ```gleam
+/// family()
+/// // -> Linux
+/// ```
+/// ```gleam
+/// family()
+/// // -> Darwin
+/// ```
+/// ```gleam
+/// family()
+/// // -> Other("sunos")
+/// ```
 ///
 @external(erlang, "gleam_erlang_ffi", "os_family")
 pub fn family() -> OsFamily

--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -144,17 +144,17 @@ pub fn receive(
 /// # Examples
 ///
 /// ```gleam
-/// > let int_subject = new_subject()
-/// > let float_subject = new_subject()
-/// > send(int_subject, 1)
-/// >
-/// > let selector =
-/// >   new_selector()
-/// >   |> selecting(int_subject, int.to_string)
-/// >   |> selecting(float_subject, float.to_string)
-/// >
-/// > select(selector, 10)
-/// Ok("1")
+/// let int_subject = new_subject()
+/// let float_subject = new_subject()
+/// send(int_subject, 1)
+/// 
+/// let selector =
+///   new_selector()
+///   |> selecting(int_subject, int.to_string)
+///   |> selecting(float_subject, float.to_string)
+/// 
+/// select(selector, 10)
+/// // -> Ok("1")
 /// ```
 ///
 pub type Selector(payload)
@@ -756,13 +756,16 @@ pub fn named(name: Atom) -> Result(Pid, Nil)
 /// it is.
 ///
 /// ## Examples
-///
-///    > import gleam/dynamic
-///    > from_dynamic(dynamic.from(process.self()))
-///    Ok(process.self())
-///
-///    > from_dynamic(dynamic.from(123))
-///    Error([DecodeError(expected: "Pid", found: "Int", path: [])])
-///
+/// 
+/// ```gleam
+/// import gleam/dynamic
+/// from_dynamic(dynamic.from(process.self()))
+/// // -> Ok(process.self())
+/// ```
+/// 
+/// ```gleam
+/// from_dynamic(dynamic.from(123))
+/// // -> Error([DecodeError(expected: "Pid", found: "Int", path: [])])
+/// ```
 @external(erlang, "gleam_erlang_ffi", "pid_from_dynamic")
 pub fn pid_from_dynamic(from from: Dynamic) -> Result(Pid, DecodeErrors)

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -389,12 +389,12 @@ pub fn send_after_test() {
 
   // 0 is received immediately, though asynchronously
   process.send_after(subject, 0, "a")
-  let assert Ok("a") = process.receive(subject, 10)
+  let assert Ok("a") = process.receive(subject, 50)
 
   // With a delay it is sent later
   process.send_after(subject, 5, "b")
   let assert Error(Nil) = process.receive(subject, 0)
-  let assert Ok("b") = process.receive(subject, 10)
+  let assert Ok("b") = process.receive(subject, 50)
 }
 
 pub fn cancel_timer_test() {
@@ -407,7 +407,7 @@ pub fn cancel_timer_test() {
 pub fn cancel_already_fired_timer_test() {
   let subject = process.new_subject()
   let timer = process.send_after(subject, 0, "a")
-  let assert Ok(_) = process.receive(subject, 5)
+  let assert Ok(_) = process.receive(subject, 50)
   let assert process.TimerNotFound = process.cancel_timer(timer)
 }
 


### PR DESCRIPTION
This PR fixes rendering issues with the docs using the same style as `gleam_stdlib`.

Also resolves #53: I used similar timeouts (ms) as in elsewhere in this file, because on my machine tests were inconsistently failing due to not waiting long enough.

## An Example

Before:
![image](https://github.com/user-attachments/assets/3a9fe7da-d02a-409c-88c3-82f0999d4727)

After:
![image](https://github.com/user-attachments/assets/a985c2ff-9b39-4fc9-a312-f14ee08a9bbc)


