### PR TITLE
Add port_from_dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased - 2024-08-19
 
-- Add `port_from_dynamic` for decoding an 
-  [Erlang Port](https://www.erlang.org/doc/system/ports). 
+- Add `port_from_dynamic` for decoding 
+  [Erlang Port](https://www.erlang.org/doc/system/ports).
+- Add `gleam/erlang/port` and the `Port` type.
 
 ## v0.25.0 - 2024-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased - 2024-08-19
+
+- Add `port_from_dynamic` for decoding an 
+  [Erlang Port](https://www.erlang.org/doc/system/ports). 
+
 ## v0.25.0 - 2024-03-20
 
 - Updated for `gleam_stdlib` v0.33.0.

--- a/src/gleam/erlang/port.gleam
+++ b/src/gleam/erlang/port.gleam
@@ -1,0 +1,27 @@
+
+import gleam/dynamic.{type DecodeErrors, type Dynamic}
+
+/// Ports are how code running on the Erlang virtual machine interacts with
+/// the outside world. Bytes of data can be sent to and read from ports,
+/// providing a form of message passing to an external program or resource.
+///
+/// For more information on ports see the [Erlang ports documentation][1].
+///
+/// [1]: https://erlang.org/doc/reference_manual/ports.html
+///
+pub type Port
+
+/// Checks to see whether a `Dynamic` value is a pid, and return the pid if
+/// it is.
+///
+/// ## Examples
+///
+///    > import gleam/dynamic
+///    > from_dynamic(dynamic.from(process.self()))
+///    Ok(process.self())
+///
+///    > from_dynamic(dynamic.from(123))
+///    Error([DecodeError(expected: "Pid", found: "Int", path: [])])
+///
+@external(erlang, "gleam_erlang_ffi", "port_from_dynamic")
+pub fn port_from_dynamic(from from: Dynamic) -> Result(Port, DecodeErrors)

--- a/src/gleam/erlang/port.gleam
+++ b/src/gleam/erlang/port.gleam
@@ -1,4 +1,3 @@
-
 import gleam/dynamic.{type DecodeErrors, type Dynamic}
 
 /// Ports are how code running on the Erlang virtual machine interacts with

--- a/src/gleam/erlang/port.gleam
+++ b/src/gleam/erlang/port.gleam
@@ -10,7 +10,7 @@ import gleam/dynamic.{type DecodeErrors, type Dynamic}
 ///
 pub type Port
 
-/// Checks to see whether a `Dynamic` value is a pid, and return the pid if
+/// Checks to see whether a `Dynamic` value is a port, and return the port if
 /// it is.
 ///
 /// ## Examples
@@ -20,7 +20,7 @@ pub type Port
 ///    Ok(process.self())
 ///
 ///    > from_dynamic(dynamic.from(123))
-///    Error([DecodeError(expected: "Pid", found: "Int", path: [])])
+///    Error([DecodeError(expected: "Port", found: "Int", path: [])])
 ///
 @external(erlang, "gleam_erlang_ffi", "port_from_dynamic")
 pub fn port_from_dynamic(from from: Dynamic) -> Result(Port, DecodeErrors)

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -6,7 +6,7 @@
     new_selector/0, link/1, insert_selector_handler/3, select/1, select/2,
     trap_exits/1, map_selector/2, merge_selector/2, flush_messages/0,
     priv_directory/1, connect_node/1, register_process/2, unregister_process/1,
-    process_named/1, identity/1, pid_from_dynamic/1
+    process_named/1, identity/1, pid_from_dynamic/1, port_from_dynamic/1
 ]).
 
 -spec atom_from_string(binary()) -> {ok, atom()} | {error, atom_not_loaded}.
@@ -24,6 +24,11 @@ pid_from_dynamic(Data) when is_pid(Data) ->
     {ok, Data};
 pid_from_dynamic(Data) ->
     {error, [{decode_error, <<"Pid">>, gleam@dynamic:classify(Data), []}]}.
+
+port_from_dynamic(Data) when is_port(Data) ->
+    {ok, Data};
+port_from_dynamic(Data) ->
+    {error, [{decode_error, <<"Port">>, gleam@dynamic:classify(Data), []}]}.
 
 -spec get_line(io:prompt()) -> {ok, unicode:unicode_binary()} | {error, eof | no_data}.
 get_line(Prompt) ->

--- a/test/gleam/erlang/port_test.gleam
+++ b/test/gleam/erlang/port_test.gleam
@@ -1,0 +1,27 @@
+import gleam/dynamic.{DecodeError}
+import gleam/erlang/port
+import gleeunit/should
+
+type PortName {
+  Spawn(String)
+}
+
+type PortSetting
+
+@external(erlang, "erlang", "open_port")
+fn open_port(
+  port_name: PortName,
+  port_settings: List(PortSetting),
+) -> dynamic.Dynamic
+
+pub fn port_dynamic_test() {
+  let msg = open_port(Spawn("echo \"hello world\""), [])
+
+  msg
+  |> port.port_from_dynamic
+  |> should.be_ok()
+
+  let assert Error([DecodeError(expected: "Port", found: "Int", path: [])]) =
+    dynamic.from(1)
+    |> port.port_from_dynamic
+}


### PR DESCRIPTION
Replicates behavior similar to `pid_from_dynamic` for handling  Erlang ports