### PR TITLE
add erlang.format example

### DIFF
--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -7,6 +7,18 @@ import gleam/list
 fn erl_format(a: String, b: List(a)) -> Charlist
 
 /// Return a string representation of any term
+///
+/// # Example
+///
+/// ```gleam
+/// let input = erlang.get_line("Enter a name: ")
+/// // > Enter a name: <- Gleam
+/// // Returns type "Result(String, GetLineError)"
+/// let formatted_input = erlang.format(input)
+/// io.print(formatted_input)
+/// // -> {ok,<<"Gleam\n">>}%
+/// // Returns type String
+/// ```
 pub fn format(term: any) -> String {
   charlist.to_string(erl_format("~p", [term]))
 }

--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -12,6 +12,7 @@ fn erl_format(a: String, b: List(a)) -> Charlist
 ///
 /// ```gleam
 /// erlang.format(input)
+/// // -> {ok,<<"Gleam\n">>}%
 /// ```
 pub fn format(term: any) -> String {
   charlist.to_string(erl_format("~p", [term]))

--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -11,13 +11,9 @@ fn erl_format(a: String, b: List(a)) -> Charlist
 /// # Example
 ///
 /// ```gleam
-/// let input = erlang.get_line("Enter a name: ")
-/// // > Enter a name: <- Gleam
-/// // Returns type "Result(String, GetLineError)"
 /// let formatted_input = erlang.format(input)
 /// io.print(formatted_input)
 /// // -> {ok,<<"Gleam\n">>}%
-/// // Returns type String
 /// ```
 pub fn format(term: any) -> String {
   charlist.to_string(erl_format("~p", [term]))

--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -11,9 +11,7 @@ fn erl_format(a: String, b: List(a)) -> Charlist
 /// # Example
 ///
 /// ```gleam
-/// let formatted_input = erlang.format(input)
-/// io.print(formatted_input)
-/// // -> {ok,<<"Gleam\n">>}%
+/// erlang.format(input)
 /// ```
 pub fn format(term: any) -> String {
   charlist.to_string(erl_format("~p", [term]))


### PR DESCRIPTION
Hey team!

I noticed that `erlang.format` doesn't have an example, while it's simple enough to figure out, I figured it can't hurt! (it took me too long to figure out 😅)

I attempted to keep the example in line with other examples, such as `get_line`, but feel free to edit as you see fit.

Thanks!