### PR TITLE
Deselecting ProcessDown monitor (Issue #58)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           otp-version: "26.2"
           rebar3-version: "3"
-          gleam-version: "1.0.0"
+          gleam-version: "1.5.1"
       - run: gleam test
       - run: gleam format --check src test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.28.0 - 2024-10-21
+
+- The `gleam/erlang/process` module gains the `deselecting_process_down`
+  function.
+
 ## v0.27.0 - 2024-09-30
 
 - Add `reference_from_dynamic` to `gleam/erlang` for decoding references

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "gleam_erlang"
 
-version = "0.27.0"
+version = "0.28.0"
 licences = ["Apache-2.0"]
 description = "A Gleam library for working with Erlang"
 

--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -453,6 +453,12 @@ fn insert_selector_handler(
   mapping mapping: fn(message) -> payload,
 ) -> Selector(payload)
 
+@external(erlang, "gleam_erlang_ffi", "remove_selector_handler")
+fn remove_selector_handler(
+  a: Selector(payload),
+  for for: tag,
+) -> Selector(payload)
+
 /// Suspends the process calling this function for the specified number of
 /// milliseconds.
 ///
@@ -511,7 +517,9 @@ pub fn monitor_process(pid: Pid) -> ProcessMonitor {
 }
 
 /// Add a `ProcessMonitor` to a `Selector` so that the `ProcessDown` message can
-/// be received using the `Selector` and the `select` function.
+/// be received using the `Selector` and the `select` function. The
+/// `ProcessMonitor` can be removed later with
+/// [`deselecting_process_down`](#deselecting_process_down).
 ///
 pub fn selecting_process_down(
   selector: Selector(payload),
@@ -541,6 +549,17 @@ pub type CallError(msg) {
   /// time.
   ///
   CallTimeout
+}
+
+/// Remove a `ProcessMonitor` from a `Selector` prevoiusly added by
+/// [`selecting_process_down`](#selecting_process_down). If the `ProcessMonitor` is not in the
+/// `Selector` it will be returned unchanged.
+///
+pub fn deselecting_process_down(
+  selector: Selector(payload),
+  monitor: ProcessMonitor,
+) -> Selector(payload) {
+  remove_selector_handler(selector, monitor.tag)
 }
 
 // This function is based off of Erlang's gen:do_call/4.

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -3,8 +3,9 @@
     atom_from_dynamic/1, rescue/1, atom_from_string/1, get_line/1,
     ensure_all_started/1, sleep/1, os_family/0, sleep_forever/0,
     get_all_env/0, get_env/1, set_env/2, unset_env/1, demonitor/1,
-    new_selector/0, link/1, insert_selector_handler/3, select/1, select/2,
-    trap_exits/1, map_selector/2, merge_selector/2, flush_messages/0,
+    new_selector/0, link/1, insert_selector_handler/3,
+    remove_selector_handler/2, select/1, select/2, trap_exits/1,
+    map_selector/2, merge_selector/2, flush_messages/0,
     priv_directory/1, connect_node/1, register_process/2, unregister_process/1,
     process_named/1, identity/1, pid_from_dynamic/1, reference_from_dynamic/1,
     port_from_dynamic/1
@@ -118,6 +119,9 @@ merge_selector({selector, HandlersA}, {selector, HandlersB}) ->
 
 insert_selector_handler({selector, Handlers}, Tag, Fn) ->
     {selector, Handlers#{Tag => Fn}}.
+
+remove_selector_handler({selector, Handlers}, Tag) ->
+    {selector, maps:remove(Tag, Handlers)}.
 
 select(Selector) ->
     {ok, Message} = select(Selector, infinity),

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -139,8 +139,9 @@ pub fn demonitor_test() {
 
   // Monitor child
   let monitor = process.monitor_process(pid)
+  let empty_selector = process.new_selector()
   let selector =
-    process.new_selector()
+    empty_selector
     |> process.selecting_process_down(monitor, fn(x) { x })
 
   // Shutdown child to trigger monitor
@@ -152,6 +153,10 @@ pub fn demonitor_test() {
 
   // There is no down message
   let assert Error(Nil) = process.select(selector, 5)
+
+  // Remove monitor from selector
+  let assert True =
+    empty_selector == selector |> process.deselecting_process_down(monitor)
 }
 
 pub fn try_call_test() {


### PR DESCRIPTION
Add `deselecting_process_down` function to gleam/erlang/process module in order to remove a `ProcessDown` monitor from a `Selector` that has been previously added by `selecting_process_down`.
Ref. issue #58 