### PR TITLE
Add `call_forever` and `try_call_forever`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- The `gleam/erlang/process` module gains the `call_forever` and
+  `try_call_forever` functions.
+
 ## v0.28.0 - 2024-10-24
 
 - The `gleam/erlang/process` module gains the `deselecting_process_down`

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -199,6 +199,26 @@ pub fn try_call_timeout_test() {
     process.try_call(call_subject, fn(x) { x }, 10)
 }
 
+pub fn try_call_forever_test() {
+  let parent_subject = process.new_subject()
+
+  process.start(linked: True, running: fn() {
+    // Send the child subject to the parent so it can call the child
+    let child_subject = process.new_subject()
+    process.send(parent_subject, child_subject)
+    // Wait for the subject to be messaged
+    let assert Ok(#(x, reply)) = process.receive(child_subject, 50)
+    // Reply
+    process.send(reply, x + 1)
+  })
+
+  let assert Ok(call_subject) = process.receive(parent_subject, 50)
+
+  // Call the child process and get a response.
+  let assert Ok(2) =
+    process.try_call_forever(call_subject, fn(subject) { #(1, subject) })
+}
+
 pub fn call_test() {
   let parent_subject = process.new_subject()
 
@@ -216,6 +236,26 @@ pub fn call_test() {
 
   // Call the child process and get a response.
   let assert 2 = process.call(call_subject, fn(subject) { #(1, subject) }, 50)
+}
+
+pub fn call_forever_test() {
+  let parent_subject = process.new_subject()
+
+  process.start(linked: True, running: fn() {
+    // Send the child subject to the parent so it can call the child
+    let child_subject = process.new_subject()
+    process.send(parent_subject, child_subject)
+    // Wait for the subject to be messaged
+    let assert Ok(#(x, reply)) = process.receive(child_subject, 50)
+    // Reply
+    process.send(reply, x + 1)
+  })
+
+  let assert Ok(call_subject) = process.receive(parent_subject, 50)
+
+  // Call the child process and get a response.
+  let assert 2 =
+    process.call_forever(call_subject, fn(subject) { #(1, subject) })
 }
 
 @external(erlang, "erlang", "send")


### PR DESCRIPTION
This PR closes #60. I've added a panicking `call_forever` (it could still fail if the called process crashes) and `try_call_forever` to mirror `call` and `try_call`, let me know if that's ok!