### PR TITLE
Add phash2/1 and phash2/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- The `gleam/erlang` module gains the `hash` and
+  `bounded_hash` functions.
+
 ## v0.30.0 - 2024-11-11
 
 - The `gleam/erlang/process` module gains the `deselecting` function.

--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -206,3 +206,19 @@ pub fn reference_from_dynamic(
 ///
 @external(erlang, "gleam_erlang_ffi", "priv_directory")
 pub fn priv_directory(name: String) -> Result(String, Nil)
+
+/// Portable hash function that gives the same hash for the
+/// same Gleam/Erlang term regardless of machine architecture and
+/// ERTS version.
+///
+/// The function returns a hash value for Term within the range 0..limit-1.
+/// The maximum value for limit is 2^32.
+///
+/// <https://www.erlang.org/doc/apps/erts/erlang.html#phash2/2>
+@external(erlang, "erlang", "phash2")
+pub fn hash_range(term: anything, limit limit: Int) -> Int
+
+/// Equivalent to hash_range.
+/// Returns a value in the range 0..2^27-1
+@external(erlang, "erlang", "phash2")
+pub fn hash(term: anything) -> Int

--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -216,7 +216,7 @@ pub fn priv_directory(name: String) -> Result(String, Nil)
 ///
 /// <https://www.erlang.org/doc/apps/erts/erlang.html#phash2/2>
 @external(erlang, "erlang", "phash2")
-pub fn hash_range(term: anything, limit limit: Int) -> Int
+pub fn bounded_hash(term: anything, limit limit: Int) -> Int
 
 /// Equivalent to hash_range.
 /// Returns a value in the range 0..2^27-1

--- a/test/gleam/erlang_test.gleam
+++ b/test/gleam/erlang_test.gleam
@@ -80,10 +80,10 @@ pub fn priv_directory_test() {
   let assert True = string.ends_with(dir, "/gleam_stdlib/priv")
 }
 
-pub fn hash_range_test() {
-  let assert 9 = erlang.hash_range("hello", limit: 10)
-  let assert 0 = erlang.hash_range([5, 2, 8], limit: 10)
-  let assert 82 = erlang.hash_range(Ok(#("testing", 123)), limit: 200)
+pub fn bounded_hash_test() {
+  let assert 9 = erlang.bounded_hash("hello", limit: 10)
+  let assert 0 = erlang.bounded_hash([5, 2, 8], limit: 10)
+  let assert 82 = erlang.bounded_hash(Ok(#("testing", 123)), limit: 200)
 }
 
 pub fn hash_test() {

--- a/test/gleam/erlang_test.gleam
+++ b/test/gleam/erlang_test.gleam
@@ -79,3 +79,15 @@ pub fn priv_directory_test() {
   let assert Ok(dir) = erlang.priv_directory("gleam_stdlib")
   let assert True = string.ends_with(dir, "/gleam_stdlib/priv")
 }
+
+pub fn hash_range_test() {
+  let assert 9 = erlang.hash_range("hello", limit: 10)
+  let assert 0 = erlang.hash_range([5, 2, 8], limit: 10)
+  let assert 82 = erlang.hash_range(Ok(#("testing", 123)), limit: 200)
+}
+
+pub fn hash_test() {
+  let assert 47_480_723 = erlang.hash("hello")
+  let assert 79_761_634 = erlang.hash([5, 2, 8])
+  let assert 133_777_698 = erlang.hash(Ok(#("testing", 123)))
+}


### PR DESCRIPTION
Adds bindings for Erlang's portable hashing function `phash2`.

 I'm not super happy with the name `hash_range`, but I couldn't think of anything better...