### PR TITLE
`send_abnormal_exit` should not include Abnormal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- `send_abnormal_exit` no longer includes `Abnormal(...)` in the reason,
+  in order to be compatible with `selecting_trapped_exits`.
+
 ## v0.32.0 - 2024-11-28
 
 - The `gleam/os` environment functions have been deprecated in favour of the

--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -787,7 +787,7 @@ pub fn send_exit(to pid: Pid) -> Nil {
 /// [1]: http://erlang.org/doc/man/erlang.html#exit-2
 ///
 pub fn send_abnormal_exit(pid: Pid, reason: String) -> Nil {
-  erlang_send_exit(pid, Abnormal(reason))
+  erlang_send_exit(pid, reason)
   Nil
 }
 

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -560,6 +560,23 @@ pub fn selecting_trapped_exits_test() {
   let assert True = pid == exited
 }
 
+pub fn selecting_abnormal_exit_test() {
+  process.flush_messages()
+
+  process.trap_exits(True)
+  let pid =
+    process.start(linked: True, running: fn() {
+      process.send_abnormal_exit(process.self(), "reason")
+    })
+
+  let assert Ok(process.ExitMessage(exited, process.Abnormal("reason"))) =
+    process.new_selector()
+    |> process.selecting_trapped_exits(function.identity)
+    |> process.select(10)
+
+  let assert True = pid == exited
+}
+
 pub fn flush_messages_test() {
   let subject = process.new_subject()
   process.send(subject, 1)


### PR DESCRIPTION
Resolves #66

Assuming the `selecting_trapped_exits` implementation is correct, we shouldn't include the `Abnormal(...)` wrapper in the exit reason.

I started looking into this when I noticed that stopping an actor with `Abnormal` was not working as expected. I'll open a separate PR for that change in the otp repo soon.