### PR TITLE
Fix and improve process exit reason handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Change `process.Abnormal` to hold a `Dynamic` value instead of a `String`,
+  in order to avoid encoding exit reasons such as panics as strings.
+- `send_abnormal_exit` no longer includes `Abnormal(...)` in the reason,
+  in order to be better compatible with `selecting_trapped_exits`.
+- `ProcessDown` and `CalleeDown` contain `ExitReason` instead of `Dynamic` as the reason.
+
 ## v0.33.0 - 2024-12-05
 
 - The `gleam/erlang/process` module gains the `receive_forever` function.

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -118,7 +118,26 @@ pub fn selector_test() {
   let assert Error(Nil) = process.select(selector, 0)
 }
 
-pub fn monitor_test() {
+pub fn monitor_normal_exit_test() {
+  monitor_process_exit(fn() { Nil })
+  |> should.equal(process.Normal)
+}
+
+pub fn monitor_killed_test() {
+  monitor_process_exit(fn() { process.kill(process.self()) })
+  |> should.equal(process.Killed)
+}
+
+pub fn monitor_abnormal_exit_test() {
+  monitor_process_exit(fn() {
+    process.send_abnormal_exit(process.self(), "reason")
+  })
+  |> should.equal(process.Abnormal(dynamic.from("reason")))
+}
+
+/// Spawns a child, monitors exits, runs `terminating_with` in the child,
+/// checks that a `ProcessDown` is received, and finally returns the exit reason.
+fn monitor_process_exit(terminating_with: fn() -> Nil) -> process.ExitReason {
   // Spawn child
   let parent_subject = process.new_subject()
   let pid =
@@ -126,7 +145,8 @@ pub fn monitor_test() {
       let subject = process.new_subject()
       process.send(parent_subject, subject)
       // Wait for the parent to send a message before exiting
-      process.receive(subject, 150)
+      let assert Ok(_) = process.receive(subject, 150)
+      terminating_with()
     })
 
   // Monitor child
@@ -138,14 +158,15 @@ pub fn monitor_test() {
   // There is no monitor message while the child is alive
   let assert Error(Nil) = process.select(selector, 0)
 
-  // Shutdown child to trigger monitor
+  // Terminate child to trigger monitor
   let assert Ok(child_subject) = process.receive(parent_subject, 50)
   process.send(child_subject, Nil)
 
   // We get a process down message!
-  let assert Ok(ProcessDown(downed_pid, _reason)) = process.select(selector, 50)
-
+  let assert Ok(ProcessDown(downed_pid, reason)) = process.select(selector, 50)
   let assert True = downed_pid == pid
+
+  reason
 }
 
 pub fn demonitor_test() {
@@ -566,19 +587,40 @@ pub fn merge_selector_test() {
   let assert #("b", 2) = process.select_forever(selector)
 }
 
-pub fn selecting_trapped_exits_test() {
+pub fn selecting_trapped_exits_kill_test() {
+  selecting_trapped_exits(fn() { process.kill(process.self()) })
+  |> should.equal(process.Killed)
+}
+
+pub fn selecting_trapped_exits_abnormal_test() {
+  selecting_trapped_exits(fn() {
+    process.send_abnormal_exit(process.self(), "reason")
+  })
+  |> should.equal(process.Abnormal(dynamic.from("reason")))
+}
+
+pub fn selecting_trapped_exits_normal_test() {
+  selecting_trapped_exits(fn() { Nil })
+  |> should.equal(process.Normal)
+}
+
+/// Traps exits, starts a linked child, runs `terminating_with` in the child,
+/// expects an `ExitMessage`, and returns the exit reason
+pub fn selecting_trapped_exits(
+  terminating_with: fn() -> Nil,
+) -> process.ExitReason {
   process.flush_messages()
 
   process.trap_exits(True)
-  let pid = process.start(linked: True, running: fn() { process.sleep(100) })
-  process.kill(pid)
-
-  let assert Ok(process.ExitMessage(exited, process.Killed)) =
+  let exits =
     process.new_selector()
     |> process.selecting_trapped_exits(function.identity)
-    |> process.select(10)
+  let pid = process.start(linked: True, running: terminating_with)
 
+  let assert Ok(process.ExitMessage(exited, reason)) = process.select(exits, 10)
   let assert True = pid == exited
+
+  reason
 }
 
 pub fn flush_messages_test() {


### PR DESCRIPTION
- Change `process.Abnormal` to hold a `Dynamic` value instead of a `String`,
  in order to avoid encoding exit reasons such as panics as strings.
- `send_abnormal_exit` no longer includes `Abnormal(...)` in the reason,
  in order to be better compatible with `selecting_trapped_exits`.
- `ProcessDown` and `CalleeDown` contain `ExitReason` instead of `Dynamic` as the reason.

Resolves #66