### PR TITLE
Simplify process.receive/send and add receive_forever function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.33.0 - 2024-12-03
+
+- The `gleam/erlang/process` module gains the `receive_forever` function.
+
 ## v0.32.0 - 2024-11-28
 
 - The `gleam/os` environment functions have been deprecated in favour of the

--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -78,6 +78,11 @@ pub fn subject_owner(subject: Subject(message)) -> Pid {
   subject.owner
 }
 
+type DoNotLeak
+
+@external(erlang, "erlang", "send")
+fn raw_send(a: Pid, b: message) -> DoNotLeak
+
 /// Send a message to a process using a `Subject`. The message must be of the
 /// type that the `Subject` accepts.
 ///
@@ -102,8 +107,10 @@ pub fn subject_owner(subject: Subject(message)) -> Pid {
 /// send(subject, "Hello, Joe!")
 /// ```
 ///
-@external(erlang, "gleam_erlang_ffi", "send")
-pub fn send(subject: Subject(message), message: message) -> Nil
+pub fn send(subject: Subject(message), message: message) -> Nil {
+  raw_send(subject.owner, #(subject.tag, message))
+  Nil
+}
 
 /// Receive a message that has been sent to current process using the `Subject`.
 ///

--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -121,13 +121,16 @@ pub fn send(subject: Subject(message), message: message) -> Nil
 /// The `within` parameter specifies the timeout duration in milliseconds.
 ///
 @external(erlang, "gleam_erlang_ffi", "receive")
-pub fn receive_forever(from subject: Subject(message)) -> message
-
-@external(erlang, "gleam_erlang_ffi", "receive")
 pub fn receive(
   from subject: Subject(message),
   within timeout: Int,
 ) -> Result(message, Nil)
+
+/// Receive a message that has been sent to current process using the `Subject`.
+///
+/// Same as `receive` but waits forever and returns the message as is.
+@external(erlang, "gleam_erlang_ffi", "receive")
+pub fn receive_forever(from subject: Subject(message)) -> message
 
 /// A type that enables a process to wait for messages from multiple `Subject`s
 /// at the same time, returning whichever message arrives first.

--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -78,11 +78,6 @@ pub fn subject_owner(subject: Subject(message)) -> Pid {
   subject.owner
 }
 
-type DoNotLeak
-
-@external(erlang, "erlang", "send")
-fn raw_send(a: Pid, b: message) -> DoNotLeak
-
 /// Send a message to a process using a `Subject`. The message must be of the
 /// type that the `Subject` accepts.
 ///
@@ -107,10 +102,8 @@ fn raw_send(a: Pid, b: message) -> DoNotLeak
 /// send(subject, "Hello, Joe!")
 /// ```
 ///
-pub fn send(subject: Subject(message), message: message) -> Nil {
-  raw_send(subject.owner, #(subject.tag, message))
-  Nil
-}
+@external(erlang, "gleam_erlang_ffi", "send")
+pub fn send(subject: Subject(message), message: message) -> Nil
 
 /// Receive a message that has been sent to current process using the `Subject`.
 ///
@@ -127,14 +120,14 @@ pub fn send(subject: Subject(message), message: message) -> Nil {
 ///
 /// The `within` parameter specifies the timeout duration in milliseconds.
 ///
+@external(erlang, "gleam_erlang_ffi", "receive")
+pub fn receive_forever(from subject: Subject(message)) -> message
+
+@external(erlang, "gleam_erlang_ffi", "receive")
 pub fn receive(
   from subject: Subject(message),
   within timeout: Int,
-) -> Result(message, Nil) {
-  new_selector()
-  |> selecting(subject, fn(x) { x })
-  |> select(within: timeout)
-}
+) -> Result(message, Nil)
 
 /// A type that enables a process to wait for messages from multiple `Subject`s
 /// at the same time, returning whichever message arrives first.

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -8,7 +8,7 @@
     map_selector/2, merge_selector/2, flush_messages/0,
     priv_directory/1, connect_node/1, register_process/2, unregister_process/1,
     process_named/1, identity/1, pid_from_dynamic/1, reference_from_dynamic/1,
-    port_from_dynamic/1
+    port_from_dynamic/1, 'receive'/1, 'receive'/2, send/2
 ]).
 
 -spec atom_from_string(binary()) -> {ok, atom()} | {error, atom_not_loaded}.
@@ -146,6 +146,24 @@ select({selector, Handlers}, Timeout) ->
     after Timeout ->
         {error, nil}
     end.
+
+'receive'({subject, _Pid, Ref}) ->
+    receive
+        {Ref, Message} ->
+            Message
+    end.
+
+'receive'({subject, _Pid, Ref}, Timeout) ->
+    receive
+        {Ref, Message} ->
+            {ok, Message}
+    after Timeout ->
+        {error, nil}
+    end.
+
+send({subject, Pid, Ref}, Message) ->
+    Pid ! {Ref, Message},
+    nil.
 
 demonitor({_, Reference}) ->
     erlang:demonitor(Reference, [flush]).

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -8,7 +8,7 @@
     map_selector/2, merge_selector/2, flush_messages/0,
     priv_directory/1, connect_node/1, register_process/2, unregister_process/1,
     process_named/1, identity/1, pid_from_dynamic/1, reference_from_dynamic/1,
-    port_from_dynamic/1, 'receive'/1, 'receive'/2, send/2
+    port_from_dynamic/1, 'receive'/1, 'receive'/2
 ]).
 
 -spec atom_from_string(binary()) -> {ok, atom()} | {error, atom_not_loaded}.
@@ -160,10 +160,6 @@ select({selector, Handlers}, Timeout) ->
     after Timeout ->
         {error, nil}
     end.
-
-send({subject, Pid, Ref}, Message) ->
-    Pid ! {Ref, Message},
-    nil.
 
 demonitor({_, Reference}) ->
     erlang:demonitor(Reference, [flush]).

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -51,6 +51,27 @@ pub fn receive_test() {
   let assert Error(Nil) = process.receive(subject, 0)
 }
 
+pub fn receive_forever_test() {
+  let subject = process.new_subject()
+
+  // Send message from self
+  process.send(subject, 0)
+
+  // Send message from another process
+  process.start(
+    fn() {
+      process.send(subject, 1)
+      process.send(subject, 2)
+    },
+    linked: True,
+  )
+
+  // Assert all the messages arrived
+  let assert 0 = process.receive_forever(subject)
+  let assert 1 = process.receive_forever(subject)
+  let assert 2 = process.receive_forever(subject)
+}
+
 pub fn is_alive_test() {
   let pid = process.start(fn() { Nil }, False)
   process.sleep(5)


### PR DESCRIPTION
Remove the use of process.select function when calling process.receive.
Also added receive_forever.
I am not really sure this is not sub-optimizing, but added it as a result of a performance discussion on the [gleam discord channel](https://discord.com/channels/768594524158427167/1312284801125847071).
