### PR TITLE
Update to stdlib 0.50 and use `dynamic/decode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed deprecation warnings with the Gleam standard library v0.53.0 or later.
+- Increased minimum required Gleam standard library version to v0.50.0.
+
 ## v0.33.1 - 2024-12-07
 
 - Fixed a bug where `process.demonitor_process` would return the incorrect

--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,7 @@ links = [
 gleam = ">= 0.32.0"
 
 [dependencies]
-gleam_stdlib = ">= 0.33.0 and < 2.0.0"
+gleam_stdlib = ">= 0.50.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
+gleeunit = ">= 1.3.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.33.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3CEAD7B153D896499C78390B22CC968620C27500C922AED3A5DD7B536F922B25" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
+  { name = "gleam_stdlib", version = "0.53.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53F3E1E56F692C20FA3E0A23650AC46592464E40D8EF3EC7F364FB328E73CDF5" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.33.0 and < 2.0.0" }
-gleeunit = { version = "~> 1.0" }
+gleam_stdlib = { version = ">= 0.50.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.3.0 and < 2.0.0" }

--- a/src/gleam/erlang.gleam
+++ b/src/gleam/erlang.gleam
@@ -1,4 +1,5 @@
-import gleam/dynamic.{type DecodeErrors, type Dynamic}
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type DecodeError}
 import gleam/erlang/atom.{type Atom}
 import gleam/erlang/charlist.{type Charlist}
 import gleam/list
@@ -190,7 +191,7 @@ pub fn make_reference() -> Reference
 @external(erlang, "gleam_erlang_ffi", "reference_from_dynamic")
 pub fn reference_from_dynamic(
   from from: Dynamic,
-) -> Result(Reference, DecodeErrors)
+) -> Result(Reference, List(DecodeError))
 
 /// Returns the path of a package's `priv` directory, where extra non-Gleam
 /// or Erlang files are typically kept.

--- a/src/gleam/erlang/atom.gleam
+++ b/src/gleam/erlang/atom.gleam
@@ -1,4 +1,5 @@
-import gleam/dynamic.{type DecodeErrors, type Dynamic}
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type DecodeError}
 
 /// Atom is a special string-like data-type that is most commonly used for
 /// interfacing with code written in other BEAM languages such as Erlang and
@@ -81,4 +82,4 @@ pub fn to_string(a: Atom) -> String
 /// ```
 ///
 @external(erlang, "gleam_erlang_ffi", "atom_from_dynamic")
-pub fn from_dynamic(from from: Dynamic) -> Result(Atom, DecodeErrors)
+pub fn from_dynamic(from from: Dynamic) -> Result(Atom, List(DecodeError))

--- a/src/gleam/erlang/port.gleam
+++ b/src/gleam/erlang/port.gleam
@@ -1,4 +1,5 @@
-import gleam/dynamic.{type DecodeErrors, type Dynamic}
+import gleam/dynamic.{type Dynamic}
+import gleam/dynamic/decode.{type DecodeError}
 
 /// Ports are how code running on the Erlang virtual machine interacts with
 /// the outside world. Bytes of data can be sent to and read from ports,
@@ -16,11 +17,11 @@ pub type Port
 /// ## Examples
 ///
 ///    > import gleam/dynamic
-///    > from_dynamic(dynamic.from(process.self()))
+///    > port_from_dynamic(dynamic.from(process.self()))
 ///    Ok(process.self())
 ///
-///    > from_dynamic(dynamic.from(123))
+///    > port_from_dynamic(dynamic.from(123))
 ///    Error([DecodeError(expected: "Port", found: "Int", path: [])])
 ///
 @external(erlang, "gleam_erlang_ffi", "port_from_dynamic")
-pub fn port_from_dynamic(from from: Dynamic) -> Result(Port, DecodeErrors)
+pub fn port_from_dynamic(from from: Dynamic) -> Result(Port, List(DecodeError))

--- a/test/gleam/erlang/atom_test.gleam
+++ b/test/gleam/erlang/atom_test.gleam
@@ -1,4 +1,5 @@
-import gleam/dynamic.{DecodeError}
+import gleam/dynamic
+import gleam/dynamic/decode.{DecodeError}
 import gleam/erlang/atom
 
 pub fn from_string_test() {

--- a/test/gleam/erlang/charlist_test.gleam
+++ b/test/gleam/erlang/charlist_test.gleam
@@ -22,12 +22,15 @@ pub fn empty_string_test() {
   let assert "" =
     []
     |> dynamic.from
-    |> dynamic.unsafe_coerce
+    |> unsafe_coerce
     |> charlist.to_string
 
   let assert [] =
     ""
     |> charlist.from_string()
     |> dynamic.from
-    |> dynamic.unsafe_coerce
+    |> unsafe_coerce
 }
+
+@external(erlang, "gleam_erlang_ffi", "identity")
+fn unsafe_coerce(a: dynamic.Dynamic) -> anything

--- a/test/gleam/erlang/port_test.gleam
+++ b/test/gleam/erlang/port_test.gleam
@@ -1,4 +1,5 @@
-import gleam/dynamic.{DecodeError}
+import gleam/dynamic
+import gleam/dynamic/decode.{DecodeError}
 import gleam/erlang/port
 import gleeunit/should
 

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -1,4 +1,5 @@
-import gleam/dynamic.{DecodeError}
+import gleam/dynamic
+import gleam/dynamic/decode.{DecodeError}
 import gleam/erlang/atom
 import gleam/erlang/process.{ProcessDown}
 import gleam/float
@@ -295,21 +296,21 @@ pub fn selecting_record_test() {
 
   let assert Error(Nil) =
     process.new_selector()
-    |> process.selecting_record2("h", dynamic.unsafe_coerce)
+    |> process.selecting_record2("h", unsafe_coerce)
     |> process.select(0)
 
   let assert Error(Nil) =
     process.new_selector()
-    |> process.selecting_record2("c", dynamic.unsafe_coerce)
+    |> process.selecting_record2("c", unsafe_coerce)
     |> process.select(0)
   let assert Error(Nil) =
     process.new_selector()
-    |> process.selecting_record2("c", dynamic.unsafe_coerce)
+    |> process.selecting_record2("c", unsafe_coerce)
     |> process.select(0)
   let assert Error(Nil) =
     process.new_selector()
     |> process.selecting_record3("c", fn(a, b) {
-      #(dynamic.unsafe_coerce(a), dynamic.unsafe_coerce(b))
+      #(unsafe_coerce(a), unsafe_coerce(b))
     })
     |> process.select(0)
 
@@ -317,13 +318,13 @@ pub fn selecting_record_test() {
     process.new_selector()
     |> process.selecting_record8("g", fn(a, b, c, d, e, f, g) {
       #(
-        dynamic.unsafe_coerce(a),
-        dynamic.unsafe_coerce(b),
-        dynamic.unsafe_coerce(c),
-        dynamic.unsafe_coerce(d),
-        dynamic.unsafe_coerce(e),
-        dynamic.unsafe_coerce(f),
-        dynamic.unsafe_coerce(g),
+        unsafe_coerce(a),
+        unsafe_coerce(b),
+        unsafe_coerce(c),
+        unsafe_coerce(d),
+        unsafe_coerce(e),
+        unsafe_coerce(f),
+        unsafe_coerce(g),
       )
     })
     |> process.select(0)
@@ -332,12 +333,12 @@ pub fn selecting_record_test() {
     process.new_selector()
     |> process.selecting_record7("f", fn(a, b, c, d, e, f) {
       #(
-        dynamic.unsafe_coerce(a),
-        dynamic.unsafe_coerce(b),
-        dynamic.unsafe_coerce(c),
-        dynamic.unsafe_coerce(d),
-        dynamic.unsafe_coerce(e),
-        dynamic.unsafe_coerce(f),
+        unsafe_coerce(a),
+        unsafe_coerce(b),
+        unsafe_coerce(c),
+        unsafe_coerce(d),
+        unsafe_coerce(e),
+        unsafe_coerce(f),
       )
     })
     |> process.select(0)
@@ -346,11 +347,11 @@ pub fn selecting_record_test() {
     process.new_selector()
     |> process.selecting_record6("e", fn(a, b, c, d, e) {
       #(
-        dynamic.unsafe_coerce(a),
-        dynamic.unsafe_coerce(b),
-        dynamic.unsafe_coerce(c),
-        dynamic.unsafe_coerce(d),
-        dynamic.unsafe_coerce(e),
+        unsafe_coerce(a),
+        unsafe_coerce(b),
+        unsafe_coerce(c),
+        unsafe_coerce(d),
+        unsafe_coerce(e),
       )
     })
     |> process.select(0)
@@ -358,36 +359,27 @@ pub fn selecting_record_test() {
   let assert Ok(#(7, 8, 9, 10)) =
     process.new_selector()
     |> process.selecting_record5("d", fn(a, b, c, d) {
-      #(
-        dynamic.unsafe_coerce(a),
-        dynamic.unsafe_coerce(b),
-        dynamic.unsafe_coerce(c),
-        dynamic.unsafe_coerce(d),
-      )
+      #(unsafe_coerce(a), unsafe_coerce(b), unsafe_coerce(c), unsafe_coerce(d))
     })
     |> process.select(0)
 
   let assert Ok(#(4, 5, 6)) =
     process.new_selector()
     |> process.selecting_record4("c", fn(a, b, c) {
-      #(
-        dynamic.unsafe_coerce(a),
-        dynamic.unsafe_coerce(b),
-        dynamic.unsafe_coerce(c),
-      )
+      #(unsafe_coerce(a), unsafe_coerce(b), unsafe_coerce(c))
     })
     |> process.select(0)
 
   let assert Ok(#(2, 3)) =
     process.new_selector()
     |> process.selecting_record3("b", fn(a, b) {
-      #(dynamic.unsafe_coerce(a), dynamic.unsafe_coerce(b))
+      #(unsafe_coerce(a), unsafe_coerce(b))
     })
     |> process.select(0)
 
   let assert Ok(1) =
     process.new_selector()
-    |> process.selecting_record2("a", dynamic.unsafe_coerce)
+    |> process.selecting_record2("a", unsafe_coerce)
     |> process.select(0)
 }
 
@@ -398,11 +390,11 @@ pub fn selecting_anything_test() {
 
   let selector =
     process.new_selector()
-    |> process.selecting_anything(dynamic.int)
+    |> process.selecting_anything(decode.run(_, decode.int))
 
   let assert Ok(Ok(1)) = process.select(selector, 0)
   let assert Ok(Error([
-    dynamic.DecodeError(expected: "Int", found: "Float", path: []),
+    decode.DecodeError(expected: "Int", found: "Float", path: []),
   ])) = process.select(selector, 0)
   let assert Error(Nil) = process.select(selector, 0)
 }
@@ -656,3 +648,6 @@ pub fn deselecting_test() {
   |> process.deselecting(subject2)
   |> should.equal(selector0)
 }
+
+@external(erlang, "gleam_erlang_ffi", "identity")
+fn unsafe_coerce(a: dynamic.Dynamic) -> anything

--- a/test/gleam/erlang_test.gleam
+++ b/test/gleam/erlang_test.gleam
@@ -1,7 +1,8 @@
-import gleam/dynamic.{DecodeError}
+import gleam/dynamic
+import gleam/dynamic/decode.{DecodeError}
 import gleam/erlang.{UnknownApplication}
 import gleam/erlang/atom
-import gleam/iterator
+import gleam/list
 import gleam/string
 
 pub fn term_to_binary_test() {
@@ -42,11 +43,10 @@ pub fn ensure_all_started_unknown_test() {
 
 pub fn make_reference_test() {
   let reference = erlang.make_reference()
-  iterator.range(0, 100_000)
-  |> iterator.map(fn(_) {
+  list.range(0, 100_000)
+  |> list.each(fn(_) {
     let assert True = reference != erlang.make_reference()
   })
-  |> iterator.run
 }
 
 pub fn reference_from_dynamic_test() {


### PR DESCRIPTION
This fixes deprecation warnings on stdlib 0.53.