### PR TITLE
Fix example code under Selector type definition.

### DIFF
--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -268,7 +268,7 @@ pub fn receive_forever(from subject: Subject(message)) -> message
 ///   |> select(string_subject)
 ///   |> select_map(int_subject, int.to_string)
 ///
-/// select(selector, 10)
+/// selector_receive(selector, 10)
 /// // -> Ok("1")
 /// ```
 ///


### PR DESCRIPTION
Instead of using select to wait for a message on the `selector` we now use `selector_receive`.