### PR TITLE
Fix `process.select` documentation comments

### DIFF
--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -376,8 +376,7 @@ pub fn flush_messages() -> Nil
 /// from the receiver process inbox.
 ///
 /// See `select_map` to add subjects of a different message type.
-//
-
+///
 /// See `deselect` to remove a subject from a selector.
 ///
 pub fn select(


### PR DESCRIPTION
There was a stray `//` in the middle, splitting the comment, and making only the latter half functional.