### PR TITLE
Add `priority_subject` to send priority messages

### DIFF
--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -666,3 +666,18 @@ pub fn name_test() {
   let assert Ok("Hello") = process.receive(subject, 0)
   process.unregister(name)
 }
+
+pub fn subject_priority_test() {
+  let subject = process.new_subject()
+  let priority_subject = process.priority_subject()
+
+  process.send(subject, 123)
+  process.sleep(100)
+  process.send(priority_subject, 321)
+  let selector =
+    process.new_selector()
+    |> process.select(subject)
+    |> process.select(priority_subject)
+
+  assert process.selector_receive_forever(selector) == 321
+}


### PR DESCRIPTION
This PR attempts to implement [priority messaging from OTP 28.0](https://www.erlang.org/blog/highlights-otp-28/#priority-messages) in a backwards compatible way.

A new `PrioritySubject` is used internally that holds the priority alias, created with `priority_subject()`. Its api is identical to a regular subject created with `new_subject`, with only its behaviour being different (priority messages enters the queue in front of regular messages). Unfortunately `send_after` does not actually support sending to process aliases, so that remains unimplemented.

