### PR TITLE
Process.send docs: remove Named Subjects section

### DIFF
--- a/src/gleam/erlang/process.gleam
+++ b/src/gleam/erlang/process.gleam
@@ -183,11 +183,6 @@ fn raw_send(a: Pid, b: message) -> DoNotLeak
 /// This function does not wait for the `Subject` owner process to call the
 /// `receive` function, instead it returns once the message has been placed in
 /// the process' mailbox.
-/// 
-/// # Named Subjects
-/// 
-/// If this function is called on a named subject for which a process has not been 
-/// registered, it will simply drop the message as there's no mailbox to send it to.
 ///
 /// # Panics
 ///


### PR DESCRIPTION
As of c54cb6ebea16580109495eef353f5747ab1d1f11 it's no longer correct; the new behaviour on sending to a named subject with no registered process is described by the 'Panics' section below