### PR TITLE
Draft: add `open_port` & `port_command` support

### DIFF
--- a/src/gleam/erlang/port.gleam
+++ b/src/gleam/erlang/port.gleam
@@ -1,4 +1,5 @@
 import gleam/dynamic
+import gleam/erlang/charlist.{type Charlist}
 
 /// Ports are how code running on the Erlang virtual machine interacts with
 /// the outside world. Bytes of data can be sent to and read from ports,
@@ -33,7 +34,7 @@ pub fn spawn_executable(command: String) -> PortCommand {
 pub type PortOptions {
   Arg0(String)
   Args(List(String))
-  Env(List(#(String, String)))
+  Env(List(#(Charlist, Charlist)))
   Cd(String)
   Binary
 

--- a/src/gleam/erlang/port.gleam
+++ b/src/gleam/erlang/port.gleam
@@ -1,3 +1,5 @@
+import gleam/dynamic
+
 /// Ports are how code running on the Erlang virtual machine interacts with
 /// the outside world. Bytes of data can be sent to and read from ports,
 /// providing a form of message passing to an external program or resource.
@@ -7,3 +9,73 @@
 /// [1]: https://erlang.org/doc/reference_manual/ports.html
 ///
 pub type Port
+
+pub type PortCommand {
+  Spawn(String)
+  SpawnDriver(String)
+  SpawnExecutable(String)
+  Fd(in: Int, out: Int)
+}
+
+pub fn spawn(command: String) -> PortCommand {
+  Spawn(command)
+}
+
+pub fn spawn_driver(command: String) -> PortCommand {
+  SpawnDriver(command)
+}
+
+pub fn spawn_executable(command: String) -> PortCommand {
+  SpawnExecutable(command)
+}
+
+
+pub type PortOptions {
+  Arg0(String)
+  Args(List(String))
+  Env(List(#(String, String)))
+  Cd(String)
+  Binary
+
+  UseStdio
+  NouseStdio
+
+  Eof
+  ExitStatus
+
+  Stream
+  Line(Int)
+  Packet(Int) // only 1, 2, & 4
+}
+
+pub type PortError {
+  Badarg
+  SystemLimit
+  Enomem
+  Eagain
+  Enametoolong
+  Emfile
+  Enfile
+  Eaccess
+  Enoent
+}
+
+@external(erlang, "gleam_erlang_ffi", "my_open_port")
+pub fn open(
+  name: PortCommand,
+  settings: List(PortOptions),
+) -> Result(Port, PortError)
+
+@external(erlang, "erlang", "port_command")
+pub fn port_command(
+  port: Port,
+  data: BitArray,
+  options: List(PortOptions),
+) -> Nil
+
+
+@external(erlang, "gleam_erlang_ffi", "identity")
+pub fn to_dynamic(a: Port) -> dynamic.Dynamic
+
+@external(erlang, "erlang", "port_close")
+pub fn close(port: Port) -> Nil

--- a/src/gleam/erlang/port/receive.gleam
+++ b/src/gleam/erlang/port/receive.gleam
@@ -1,0 +1,5 @@
+pub type PortData {
+  Data(BitArray)
+  ExitStatus(Int)
+  Eof
+}

--- a/test/gleam/erlang/port_test.gleam
+++ b/test/gleam/erlang/port_test.gleam
@@ -102,3 +102,19 @@ pub fn port_switchover_test() {
 
   port.close(port)
 }
+
+
+pub fn port_subject_send_test() {
+  let assert Ok(port) = port.open(
+    port.spawn_executable("/bin/bash"),
+    [port.Args(["-c", "cat"]), port.UseStdio, port.ExitStatus, port.Binary]
+  )
+
+  let subject = port_subject(port)
+
+
+  assert assert_panic(fn() { process.send(subject, Data(<<"hello">>)) })
+    == "Cannot send on PortSubject"
+
+  port.close(port)
+}

--- a/test/gleam/erlang/port_test.gleam
+++ b/test/gleam/erlang/port_test.gleam
@@ -1,0 +1,63 @@
+import gleam/erlang/port
+import gleam/erlang/port/receive.{Data, ExitStatus}
+import gleam/erlang/process.{receive, port_open, port_subject}
+
+pub fn port_open_test() {
+  let assert Ok(port) = port.open(
+    port.spawn_executable("/bin/bash"),
+    [port.Args(["-c", "echo hi | wc -c"]), port.UseStdio, port.ExitStatus, port.Binary]
+  )
+
+  let subject = port_subject(port)
+
+  assert Ok(Data(<<"3\n">>)) == receive(subject, 100)
+  assert Ok(ExitStatus(0)) == receive(subject, 100)
+  assert Error(Nil) == receive(subject, 100)
+}
+
+pub fn fail_port_open_test() {
+  let assert Error(port.Enoent) = port.open(
+    port.spawn_executable("/bin/doesntexist"),
+    []
+  )
+}
+
+pub fn port_subject_test() {
+  let assert Ok(subject) = port_open(
+    port.spawn_executable("/bin/bash"),
+    [port.Args(["-c", "echo hello | wc -c"]), port.UseStdio, port.ExitStatus, port.Binary]
+  )
+
+  assert Ok(Data(<<"6\n">>)) == receive(subject, 100)
+  assert Ok(ExitStatus(0)) == receive(subject, 100)
+  assert Error(Nil) == receive(subject, 100)
+}
+
+pub fn close_port_test() {
+  let assert Ok(port) = port.open(
+    port.spawn_executable("/bin/bash"),
+    [port.Args(["-c", "echo hi; sleep 0.25; echo yo 2> /dev/null"]), port.UseStdio, port.ExitStatus, port.Binary]
+  )
+
+  let subject = port_subject(port)
+
+  assert Ok(Data(<<"hi\n">>)) == receive(subject, 100)
+
+  port.close(port)
+
+  assert Error(Nil) == receive(subject, 300)
+}
+
+pub fn delay_port_test() {
+  let assert Ok(port) = port.open(
+    port.spawn_executable("/bin/bash"),
+    [port.Args(["-c", "echo hi; sleep 0.25; echo yo 2> /dev/null"]), port.UseStdio, port.ExitStatus, port.Binary]
+  )
+
+  let subject = port_subject(port)
+  assert Ok(Data(<<"hi\n">>)) == receive(subject, 50)
+  assert Error(Nil) == receive(subject, 100)
+  assert Ok(Data(<<"yo\n">>)) == receive(subject, 300)
+  assert Ok(ExitStatus(0)) == receive(subject, 100)
+  assert Error(Nil) == receive(subject, 100)
+}

--- a/test/gleam/erlang/port_test.gleam
+++ b/test/gleam/erlang/port_test.gleam
@@ -1,6 +1,9 @@
 import gleam/erlang/port
 import gleam/erlang/port/receive.{Data, ExitStatus}
-import gleam/erlang/process.{receive, port_open, port_subject}
+import gleam/erlang/process.{receive, port_open, port_connect, port_subject}
+
+@external(erlang, "gleam_erlang_test_ffi", "assert_gleam_panic")
+fn assert_panic(f: fn() -> t) -> String
 
 pub fn port_open_test() {
   let assert Ok(port) = port.open(
@@ -60,4 +63,42 @@ pub fn delay_port_test() {
   assert Ok(Data(<<"yo\n">>)) == receive(subject, 300)
   assert Ok(ExitStatus(0)) == receive(subject, 100)
   assert Error(Nil) == receive(subject, 100)
+}
+
+// mirrors name_other_switchover_test in process_test a bit
+pub fn port_switchover_test() {
+  // create a new port
+  let assert Ok(port) = port.open(
+    port.spawn_executable("/bin/bash"),
+    [port.Args(["-c", "cat"]), port.UseStdio, port.ExitStatus, port.Binary]
+  )
+
+  let subject = process.port_subject(port)
+
+  // verify we can listen on it
+  port.port_command(port, <<"wasd\n">>, [])
+  assert Ok(Data(<<"wasd\n">>)) == receive(subject, 5)
+
+  // switch the owner to some other erlang process
+  let pid = process.spawn(fn() { process.sleep(20) })
+  let newsubject = port_connect(port, pid)
+
+  // try to listen on it again
+  port.port_command(port, <<"test2\n">>, [])
+  assert assert_panic(fn() { process.receive(newsubject, 0) })
+    == "Cannot receive with a subject owned by another process"
+  // test the original subject, too
+  assert assert_panic(fn() { process.receive(subject, 0) })
+    == "Cannot receive with a subject owned by another process"
+
+  // let's switch back now
+  let newnewsubject = port_connect(port, process.self())
+  port.port_command(port, <<"test3\n">>, [])
+  assert Ok(Data(<<"test3\n">>)) == receive(subject, 5)
+  port.port_command(port, <<"test4\n">>, [])
+  assert Ok(Data(<<"test4\n">>)) == receive(newsubject, 5)
+  port.port_command(port, <<"test5\n">>, [])
+  assert Ok(Data(<<"test5\n">>)) == receive(newnewsubject, 5)
+
+  port.close(port)
 }

--- a/test/gleam/erlang/process_test.gleam
+++ b/test/gleam/erlang/process_test.gleam
@@ -112,6 +112,15 @@ pub fn receive_forever_test() {
   let assert 2 = process.receive_forever(subject)
 }
 
+pub fn receive_forever_other_test() {
+  let subject = process.new_subject()
+  process.spawn(fn() { process.send(subject, process.new_subject()) })
+  let subject = process.receive_forever(subject)
+
+  assert assert_panic(fn() { process.receive_forever(subject) })
+    == "Cannot receive with a subject owned by another process"
+}
+
 pub fn is_alive_test() {
   let pid = process.spawn_unlinked(fn() { Nil })
   process.sleep(5)
@@ -664,5 +673,16 @@ pub fn name_test() {
   let subject = process.named_subject(name)
   process.send(subject, "Hello")
   let assert Ok("Hello") = process.receive(subject, 0)
+  process.unregister(name)
+}
+
+pub fn name_other_test() {
+  let name = process.new_name("name")
+  let pid = process.spawn_unlinked(fn() { process.sleep(10) })
+  let assert Ok(_) = process.register(pid, name)
+  let subject = process.named_subject(name)
+  process.send(subject, "Hello")
+  assert assert_panic(fn() { process.receive(subject, 5) })
+    == "Cannot receive with a subject owned by another process"
   process.unregister(name)
 }


### PR DESCRIPTION
- [ ] remove `cast()` for unsafely_create_subject call
- [ ] figure out structure to not cause a recursive import with `gleam/erlang/process`
- [x] add error handling
- [ ] find a more gleam-y representation to mirror [feedback](https://github.com/gleam-lang/erlang/issues/89#issuecomment-3323257319)

Fixes #89