### PR TITLE
Add binding for `application:get_application()`

### DIFF
--- a/src/gleam/erlang/application.gleam
+++ b/src/gleam/erlang/application.gleam
@@ -20,6 +20,19 @@ pub type StartType {
   Failover(previous: Node)
 }
 
+/// Returns the  name of the current application, or an error if not run from
+/// inside an application.
+///
+/// # Example
+///
+/// ```gleam
+/// application.get_application()
+/// // -> Ok("my_app")
+/// ```
+///
+@external(erlang, "gleam_erlang_ffi", "get_application")
+pub fn get_application() -> Result(String, Nil)
+
 /// Returns the path of an application's `priv` directory, where extra non-Gleam
 /// or Erlang files are typically kept. Each Gleam package is an Erlang
 /// application.

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -5,7 +5,7 @@
     select/2, trap_exits/1, map_selector/2, merge_selector/2, flush_messages/0,
     priv_directory/1, connect_node/1, register_process/2, unregister_process/1,
     process_named/1, identity/1, 'receive'/1, 'receive'/2, new_name/1,
-    cast_down_message/1, cast_exit_reason/1
+    cast_down_message/1, cast_exit_reason/1, get_application/0
 ]).
 
 -spec atom_from_string(binary()) -> {ok, atom()} | {error, nil}.
@@ -118,6 +118,12 @@ trap_exits(ShouldTrap) ->
 flush_messages() ->
     receive _Message -> flush_messages()
     after 0 -> nil
+    end.
+
+get_application() ->
+    case application:get_application() of
+        {ok, Application} -> {ok, erlang:atom_to_binary(Application, utf8)};
+        _ -> {error, nil}
     end.
 
 priv_directory(Name) ->

--- a/src/gleam_erlang_ffi.erl
+++ b/src/gleam_erlang_ffi.erl
@@ -121,7 +121,8 @@ flush_messages() ->
     end.
 
 get_application() ->
-    case application:get_application() of
+    Module = module_info(module),
+    case application:get_application(Module) of
         {ok, Application} -> {ok, erlang:atom_to_binary(Application, utf8)};
         _ -> {error, nil}
     end.

--- a/test/gleam/erlang/application_test.gleam
+++ b/test/gleam/erlang/application_test.gleam
@@ -1,0 +1,5 @@
+import gleam/erlang/application
+
+pub fn get_application_test() {
+    let assert Ok("gleam_erlang") = application.get_application()
+}


### PR DESCRIPTION
This adds a binding to `get_application/0` from the Erlang application module, for use mainly with `application.priv_directory()`. For example, a web server could expose a function to automatically serve static files from the current application's priv directory.

I briefly considered binding to `get_application/1`, but that would require either separate functions for getting the application from a PID/module name or a new type, and it's much less common to have multiple applications running in Gleam than in Elixir or Erlang.